### PR TITLE
Volume rescale

### DIFF
--- a/pcgl2cache/app/common.py
+++ b/pcgl2cache/app/common.py
@@ -181,10 +181,7 @@ def handle_attributes(graph_id: str, is_binary=False):
             result[int(l2id)] = {}
             missing_l2ids.append(l2id)
     _add_offset_to_coords(graph_id, l2ids, result)
-
-    if attributes is not None:
-        if _attributes["size_nm3"] in attributes:
-            _rescale_volume(graph_id, l2ids, result)
+    _rescale_volume(graph_id, l2ids, result)
 
     try:
         _trigger_cache_update(missing_l2ids, graph_id, cache_client.table_id)

--- a/pcgl2cache/app/common.py
+++ b/pcgl2cache/app/common.py
@@ -196,7 +196,7 @@ def _rescale_volume(graph_id: str, l2ids: Iterable, result: dict):
 
     # Get volume of a supervoxel in nm3
     cv = get_l2cache_cv(graph_id)
-    sv_vol = np.array(cv.mip_resolution(0)).prod()
+    sv_vol = np.array(cv.mip_resolution(0), dtype=np.int64).prod()
 
     for l2id in l2ids:
         key = int(l2id)

--- a/pcgl2cache/app/common.py
+++ b/pcgl2cache/app/common.py
@@ -196,7 +196,7 @@ def _rescale_volume(graph_id: str, l2ids: Iterable, result: dict):
 
     # Get volume of a supervoxel in nm3
     cv = get_l2cache_cv(graph_id)
-    sv_vol = np.array(cv.mip_resolution(0), dtype=np.int64).prod()
+    sv_vol = np.array(cv.resolution).prod()
 
     for l2id in l2ids:
         key = int(l2id)


### PR DESCRIPTION
The volume data (at least for Minnie) is in supervoxels, not nm3. Given that the attribute name is nm3, we should do that conversion in the front end.

Note that I tried to match the pattern established by the offset calculation, but I don't have a configuration set up to test this code in context.